### PR TITLE
2 crete table migration for cards

### DIFF
--- a/app/Models/Card.php
+++ b/app/Models/Card.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Card extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = ['first_name', 'last_name', 'number', 'expire_date', 'security_code'];
+
+    public function user()
+    {
+        $this->hasOne(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -44,4 +44,9 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    public function cards()
+    {
+        $this->belongsToMany(Card::class);
+    }
 }

--- a/database/migrations/2023_09_22_133110_create_cards_table.php
+++ b/database/migrations/2023_09_22_133110_create_cards_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cards', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->char('number', 16)->nullable();
+            $table->date('expire_date')->nullable();
+            $table->char('security_code', 3)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cards');
+    }
+};

--- a/database/migrations/2023_09_22_133110_create_cards_table.php
+++ b/database/migrations/2023_09_22_133110_create_cards_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('cards', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            // $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('first_name')->nullable();
             $table->string('last_name')->nullable();
             $table->char('number', 16)->nullable();

--- a/database/seeders/CardSeeder.php
+++ b/database/seeders/CardSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Card;
+use Faker\Generator;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+
+class CardSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(Generator $faker): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $card = new Card();
+            $card->first_name = $faker->firstName();
+            $card->last_name = $faker->lastName();
+            $card->number = $faker->randomNumber(16, true);
+            $card->expire_date = $faker->dateTime();
+            $card->security_code = $faker->randomNumber(3, true);
+            $card->save();
+        }
+    }
+}

--- a/database/seeders/CardSeeder.php
+++ b/database/seeders/CardSeeder.php
@@ -17,7 +17,6 @@ class CardSeeder extends Seeder
     {
         for ($i = 0; $i < 10; $i++) {
             $card = new Card();
-            $card->user_id = 1;
             $card->first_name = $faker->firstName();
             $card->last_name = $faker->lastName();
             $card->number = $faker->numerify('################');

--- a/database/seeders/CardSeeder.php
+++ b/database/seeders/CardSeeder.php
@@ -17,9 +17,10 @@ class CardSeeder extends Seeder
     {
         for ($i = 0; $i < 10; $i++) {
             $card = new Card();
+            $card->user_id = 1;
             $card->first_name = $faker->firstName();
             $card->last_name = $faker->lastName();
-            $card->number = $faker->randomNumber(16, true);
+            $card->number = $faker->numerify('################');
             $card->expire_date = $faker->dateTime();
             $card->security_code = $faker->randomNumber(3, true);
             $card->save();


### PR DESCRIPTION
Creato la migration per creare la tabella delle carte di credito insieme al modello e al seeder. La foreign key della tabella delle carte è commentata per poterle generare con il seeder senza creare user